### PR TITLE
Added #Requires to examples

### DIFF
--- a/Examples/Example1.ahk
+++ b/Examples/Example1.ahk
@@ -1,4 +1,5 @@
 ﻿#include ..\Lib\Acc.ahk
+#Requires AutoHotkey v2.0-a
 
 Run("notepad.exe")
 WinWaitActive("ahk_exe notepad.exe")

--- a/Examples/Example2.ahk
+++ b/Examples/Example2.ahk
@@ -1,4 +1,5 @@
 ﻿#include ..\Lib\Acc.ahk
+#Requires AutoHotkey v2.0-a
 
 Run("notepad.exe")
 WinWaitActive("ahk_exe notepad.exe")

--- a/Examples/Example3_CaretPosition.ahk
+++ b/Examples/Example3_CaretPosition.ahk
@@ -1,4 +1,6 @@
 ﻿#include ..\Lib\Acc.ahk
+#Requires AutoHotkey v2.0-a
+
 oCaretPos := {x:0,y:0}
 Loop {
     try oCaretPos := Acc.ObjectFromWindow(, Acc.OBJID.CARET).Location

--- a/Examples/Example4_FocusEvent.ahk
+++ b/Examples/Example4_FocusEvent.ahk
@@ -1,4 +1,6 @@
 ﻿#include ..\Lib\Acc.ahk
+#Requires AutoHotkey v2.0-a
+
 Persistent()
 
 ; This won't work without assigning the registered event object to a variable

--- a/Examples/Example5_VSCode_LineColumn.ahk
+++ b/Examples/Example5_VSCode_LineColumn.ahk
@@ -1,4 +1,6 @@
 #include ..\Lib\Acc.ahk
+#Requires AutoHotkey v2.0-a
+
 Loop {
     lnCol := GetVSCodeLnCol()
     ToolTip("Ln " lnCol.Ln ", Col " lnCol.Col "`nFound elements path: " lnCol.Path)

--- a/Examples/Example6.ahk
+++ b/Examples/Example6.ahk
@@ -1,4 +1,6 @@
 #include ..\Lib\Acc.ahk
+#Requires AutoHotkey v2.0-a
+
 SetTitleMatchMode(2)
 
 Run("explore C:\")

--- a/Examples/Example7_Page_URL_From_Hover.ahk
+++ b/Examples/Example7_Page_URL_From_Hover.ahk
@@ -1,4 +1,5 @@
 ﻿#include ..\Lib\Acc.ahk
+#Requires AutoHotkey v2.0-a
 
 ; Returns the URL from the document element of a web browser. 
 ; Hover over a browser with the cursor to test it out.


### PR DESCRIPTION
Best practice is to add #Requires AutoHotkey v2.0-a to v2 scripts